### PR TITLE
Applied fix for delete button causing display values to go missing

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,11 +2,8 @@ let displayValue = ' ';
 const deleteButton = document.getElementById("delete-button");
 const addButton = document.getElementById("add-button");
 const subtractButton = document.getElementById("subtract-button");
-// 
 
-
-
-function updateDisplay(value) {
+function updateDisplay() {
   const display = document.getElementById("display");
   display.textContent = displayValue;
 }
@@ -16,19 +13,16 @@ function appendToDisplay(value) {
   updateDisplay();
 }
 
-deleteButton.addEventListener("click", function appendToDisplay(value) {
-  displayValue -= value;
-  updateDisplay();
-});
-
 function deleteCharacter() {
   var input = document.getElementById("display");
   var currentValue = input.value;
 
   if (currentValue.length > 0) {
-  var newValue = currentValue.substring(0, currentValue.length - 1);
-  input.value = newValue;
+    var newValue = currentValue.substring(0, currentValue.length - 1);
+    displayValue = newValue;
   }
+
+  updateDisplay();
 }
 
 
@@ -39,6 +33,10 @@ function clearDisplay() {
 }
 
 function calculate() {
+  if (displayValue === " ") {
+    return;
+  }
+
   try {
     const result = eval(displayValue);
     displayValue = result.toString();


### PR DESCRIPTION
### Description

When clicking the `Del` button when the values were all removed, the display value would no longer be updated, even after clicking reset. This PR fixes this behavior.

There was an extra event listener which added duplicated click logic here:

```javascript
deleteButton.addEventListener("click", function appendToDisplay(value) {
  displayValue -= value;
  updateDisplay();
});
```

But the `Del` button was already calling the `deleteCharacter` function every time it was clicked. I moved the updating of the display into that function

The `deleteCharacter` function was also setting the display's value directly, when it should just set the displayValue that was already used, that is responsible for setting the `textContent` correctly in the `updateDisplay` function